### PR TITLE
Patch to send stop events in animation.Loop

### DIFF
--- a/lime/src/animation/loop.js
+++ b/lime/src/animation/loop.js
@@ -88,6 +88,8 @@ lime.animation.Loop.prototype.handleActionEnd_ = function() {
     this.timesRun_++;
     if (this.playing_ && (!this.limit_ || this.timesRun_ < this.limit_)) {
         this.action_.play();
+    } else {
+        this.stop(); // Make sure event gets dispatched when finished
     }
 };
 


### PR DESCRIPTION
Adding stop call to handleActionEnd_ callback so that lime.animation.Event.STOP
events get fired.  This is needed for when limit_ > 0
