### PR TITLE
Added status update if 'git svn' is not available.

### DIFF
--- a/bin/lime.py
+++ b/bin/lime.py
@@ -88,6 +88,7 @@ def checkDependencies():
         
         if(retcode!=0):
             #try pure svn
+            print ('Installed Git does not support Subversion clones, trying to checkout with Subversion.')
             retcode = subprocess.Popen(subprocess.list2cmdline(["svn","checkout","http://closure-library.googlecode.com/svn/trunk/",closure_dir]),shell=True).wait()
             
             if(retcode!=0):


### PR DESCRIPTION
With older Git, such as that currently available via the RHEL repos,
init displays git's error followed by a svn checkout. This is a
confusing experience, so a simple message to clarify the situation
seems to be in order.
