### PR TITLE
Fix for Button click events in browsers

### DIFF
--- a/lime/src/button.js
+++ b/lime/src/button.js
@@ -72,7 +72,7 @@ lime.Button.State = {
 lime.Button.Event = {
     UP: 'up',
     DOWN: 'down',
-    CLICK: 'click' // touchUpInside?
+    CLICK: 'buttonClick' // Must not == 'click' - That is a DOM event that we don't want to override! (onClick)
 };
 
 /**


### PR DESCRIPTION
Using 'click' as the event name was causing double-firing bugs in
the browser (Chrome: only when developer tools is closed.)
