### PR TITLE
Setting TMX properties in a way they can be called by the name.

### DIFF
--- a/lime/src/helper/parser/tmx.js
+++ b/lime/src/helper/parser/tmx.js
@@ -40,14 +40,10 @@ lime.parser.TMX = function (file) {
     }
 
     function _parseProperties(obj, xmlNode) {
-        if (obj.properties == undefined) {
-            obj.properties = new Array();
-        }
         for (var pi = 0; pi < xmlNode.length; pi++) {
-            var ins = new Object();
-            ins.name = xmlNode[pi].attributes.getNamedItem("name").nodeValue;
-            ins.value = xmlNode[pi].attributes.getNamedItem("value").nodeValue;
-            obj.properties.push(ins);
+            var name = xmlNode[pi].attributes.getNamedItem("name").nodeValue;
+            var value = xmlNode[pi].attributes.getNamedItem("value").nodeValue;
+            obj.properties[name] = value;
         }
         return true;
     }


### PR DESCRIPTION
The name and value of each property has been set as separate fields. Changed it, so you can call a propertie by its name:

`myMap.properties.myProperty;`

Instead of checking the `myMap.properties[ i ].name` to get the `myMap.properties[ i ].value`
