### PR TITLE
Add build option to pass externs files to the compiler.

### DIFF
--- a/bin/lime.py
+++ b/bin/lime.py
@@ -284,6 +284,10 @@ def build(name,options):
     
     if options.advanced:
         call+=" -f --compilation_level=ADVANCED_OPTIMIZATIONS"
+
+    if options.externs_file:
+        for i, opt in enumerate(options.externs_file):
+            call+=" -f --externs="+opt
         
     if options.map_file:
         call+=" -f --formatting=PRETTY_PRINT -f --create_source_map="+options.map_file
@@ -348,6 +352,10 @@ Commands:
     
     parser.add_option("-a", "--advanced", dest="advanced", action="store_true",
                       help="Build uses ADVANCED_OPTIMIZATIONS mode (encouraged)")
+
+    parser.add_option('-e', '--externs', dest="externs_file", action='append',
+                      help="File with externs declarations.")
+
     parser.add_option("-o", "--output", dest="output", action="store", type="string",
                       help="Output file for build result")
     

--- a/lime/guide/7_building.md
+++ b/lime/guide/7_building.md
@@ -19,6 +19,13 @@ Though default build process strips out all whitespace, replaces local variable 
 
 To further optimize the compiled version it is encouraged that you compress it with `gzip`. [Read more](http://code.google.com/speed/page-speed/docs/payload.html#GzipCompression)
 
+### Declaring Externs
+
+To declare Externs to be used by the Advanced Compilation, use the `-e` option in the build command. This option can be passed multiple times, in case you have multiple externs files.
+
+    #!Bash
+    bin/lime.py build helloworld -o helloworld/compiled/hw_adv.js -e helloworld/externs/some_externs.js -e helloworld/externs/more_externs.js -a
+
 ## Exports
 
 As said before advanced optimizations mode replaces all variable names. This means there are no way to interact with you compiled code from some external code(for example onload handler in your HTML file). To deal with that you can define externs and exports from your code. Extern means that this variable/propery will not be renamed so you can fully interact with it from any external code. Export means variable will be renamed but a link to the new variable will be created with original name. In 99% of places you will only need export and save lot of space this way. 


### PR DESCRIPTION
Add an option to lime.py to pass externs files to the compiler command, and update the guide to mention this new option.

--Alexander
