### PR TITLE
removed directive to set viewport width to device width

### DIFF
--- a/lime/src/director.js
+++ b/lime/src/director.js
@@ -82,7 +82,7 @@ lime.Director = function(parentElement, opt_width, opt_height) {
 
         var meta = document.createElement('meta');
         meta.name = 'viewport';
-        var content = 'width=device-width,initial-scale=1.0,minimum-scale=1,' +
+        var content = 'initial-scale=1.0,minimum-scale=1,' +
             'maximum-scale=1.0,user-scalable=no';
         if ((/android/i).test(navigator.userAgent)) {
             content += ',target-densityDpi=device-dpi';


### PR DESCRIPTION
doing this allows me to be able to an icon to home screen on iphone5 which will load in full screen mode

my html file looks like

``` html
<!DOCTYPE HTML>

<html>
<head>
    <title>mygame</title>

    <meta name="viewport" content="user-scalable=0, initial-scale=1.0">
    <meta name="apple-mobile-web-app-capable" content="yes" />
    <link rel="apple-touch-icon" href="/assets/icon.png" />
    <script type="text/javascript" src="mygame.js"></script>
</head>

<body onload="mygame.start()">

</body>

</html>
```

I havent tested but im assuming my addition of the `viewport` meta tag is redundant
