### PR TITLE
An optimization for the event dispatcher

### DIFF
--- a/lime/src/events/eventdispatcher.js
+++ b/lime/src/events/eventdispatcher.js
@@ -22,6 +22,7 @@ lime.events.EventDispatcher = function(director) {
 lime.events.EventDispatcher.prototype.register = function(node, eventType) {
     if (!goog.isDef(this.handlers[eventType])) {
         this.handlers[eventType] = [node];
+        this.handlers[eventType].sorted = true;
         //base element switch here because safari fires touchend on
         //dom tree changes otherwise
         goog.events.listen(eventType.substring(0, 5) == 'touch' && node!=this.director ?
@@ -32,7 +33,7 @@ lime.events.EventDispatcher.prototype.register = function(node, eventType) {
     else {
         if (!goog.array.contains(this.handlers[eventType], node)) {
             this.handlers[eventType].push(node);
-            this.handlers[eventType].sort(lime.Node.compareNode);
+            this.handlers[eventType].sorted = false;
         }
     }
 };
@@ -61,7 +62,7 @@ lime.events.EventDispatcher.prototype.updateDispatchOrder = function(node){
     for(var eventType in this.handlers){
         var handlers = this.handlers[eventType];
         if(goog.array.contains(handlers,node)){
-            handlers.sort(lime.Node.compareNode);
+            handlers.sorted = false;
         }
     }
 }
@@ -94,6 +95,11 @@ lime.events.EventDispatcher.prototype.swallow = function(e, type, handler) {
 lime.events.EventDispatcher.prototype.handleEvent = function(e) {
 
     if (!goog.isDef(this.handlers[e.type])) return;
+
+    if (!this.handlers[e.type].sorted) {
+        this.handlers[e.type].sort(lime.Node.compareNode);
+        this.handlers[e.type].sorted = true;
+    }
 
     var handlers = this.handlers[e.type].slice(), didhandle = false;
 


### PR DESCRIPTION
I ran into some load time issues while making a map out of clickable tiles and it lead to the discovery of a couple of inefficiency's in the event dispatcher.
- The handler arrays it keeps are sorted every time something is added to it.  This wouldn't always be a problem but in my case it isn't necessary since many objects are being added at once without any user interaction.
- The handler arrays are re-sorted every time the DOM tree changes, which means they are unnecessarily sorted twice whenever an event handling node is added.  If a branch containing several nodes that handle a particular event type is moved to a different place in the DOM the array for that event type will be sorted again for each of those nodes.  It could be redundant because only one sort after the change should be necessary.

The solution I propose is to mark the arrays as unsorted instead of sorting them when the changes happen.  They will then get sorted if necessary just before they are accessed.  This has made a huge difference in the load time of my game.
