### PR TITLE
Adding a function to be able to compare lime.fill.Color

### DIFF
--- a/lime/src/fill/color.js
+++ b/lime/src/fill/color.js
@@ -146,13 +146,16 @@ lime.fill.Color.prototype.clone = function() {
 };
 
 /**
- * Compares a {lime.fill.Color} to calling {lime.fill.Color}
+ * Compares a {lime.fill.Color} to the calling {lime.fill.Color}
  * instance for equality of RGBa values.
- * @param {lime.fill.Color} a A Color.
- * @return {boolean} True if the RGBa values are equal
+ * @param {lime.fill.Color} a A Color instance.
+ * @return {boolean} True if the RGBa or hex str values are equal
  */
 lime.fill.Color.prototype.equals = function(a) {
     if (!a || !(a instanceof lime.fill.Color)) return false;
+
+    // maybe just test only one of the RGBa values
+    if (!a.r || !a.g || !a.b || !a.a) return this.str == a.str;
 
     return a.r === this.r && a.g === this.g && a.b === this.b && a.a === this.a;
 };


### PR DESCRIPTION
Initially I was doing this

``` javascript
var color1 = new lime.fill.Color([10, 10, 12]);
var color2 = new lime.fill.Color([10, 10, 100);
if (color1.str ==  color2.str) console.log('yay');
```

but I occasionally I kept forgetting to compare the `.str` and was doing `color1 === color2` which doesnt work. 

With this commit I can do the following which is a bit more explicit

``` javascript
if (color1.equals(color2)) console.log('yay');
```
