### PR TITLE
Fix potential memory leak in lime.animation.actionManager.stopAll()

### DIFF
--- a/lime/src/animation/animation.js
+++ b/lime/src/animation/animation.js
@@ -333,6 +333,7 @@ lime.animation.actionManager.stopAll = function(target) {
             this.actions[id][i].stop();
             delete this.actions[id][i];
         }
+        delete this.actions[id];
     }
 };
 


### PR DESCRIPTION
Creating and removing a lot of sprites that had animations set on them leads to a memory leak in Chrome, even after actionManager.stopAll() is called for the removed sprites. Deleting the target's entry in the actions property of actionManager fixes this leak.
