### PR TITLE
Removing excess set of border widths

### DIFF
--- a/lime/src/sprite.js
+++ b/lime/src/sprite.js
@@ -119,8 +119,10 @@ lime.Renderer.DOM.SPRITE.draw = function(el) {
     }
     if (!goog.isNull(this.stroke_)) {
         this.stroke_.setDOMStyle(el, this);
-    } else {
+        this.hadStroke_ = true;
+    } else if (this.hadStroke_) {
         goog.style.setStyle(el, 'border-width', 0);
+        this.hadStroke_ = false;
     }
 };
 


### PR DESCRIPTION
Setting the border-width over and over was taking >7% of CPU.  Now only sets border width if there was previously a stroke that needs to be hidden.
