### PR TITLE
click event is generated twice for buttons using the canvas renderer

### DIFF
--- a/lime/src/button.js
+++ b/lime/src/button.js
@@ -44,7 +44,7 @@ lime.Button = function(opt_upstate, opt_downstate) {
                 }
             });
             e.swallow(['mouseup', 'touchend'], function(e) {
-                if (t.renderer.getType() === lime.Renderer.DOM && t.hitTest(e)) {
+                if (e.type === 'touchend' || t.renderer.getType() === lime.Renderer.DOM && t.hitTest(e)) {
                     t.dispatchEvent({type: lime.Button.Event.CLICK});
                }
                this.setState(lime.Button.State.UP);


### PR DESCRIPTION
When using a DOM renderer the element that generates the "mousedown" event is different from the element that generates the "mouseup" event because of the different button states (up/down). Therefore it is necessary to manually fire the "click" event. But if the used renderer is canvas, it's the same element for both button states and the "click" event ends up being fired twice.
