### PR TITLE
Make create command work for templates with subdirectories

### DIFF
--- a/bin/lime.py
+++ b/bin/lime.py
@@ -181,8 +181,8 @@ def create(name):
         for fname in files:
             newname = fname.replace('__name__',name)
             if fname.find("__name__")!=-1:
-                os.rename(os.path.join(path,fname),os.path.join(path,newname))
-            for line in fileinput.FileInput(os.path.join(path,newname),inplace=1):
+                os.rename(os.path.join(root,fname),os.path.join(root,newname))
+            for line in fileinput.FileInput(os.path.join(root,newname),inplace=1):
                 line = line.replace('{name}',name)
                 print(line.rstrip())
             


### PR DESCRIPTION
If you have templates/default/some/nested/file.js, "path" refers to
templates/default so you'll get a file not found error when it looks for
templates/default/file.js.  "root" refers to
templates/default/some/nested (or whatever).
