### PR TITLE
Handle passing an array of types to Node.listen

### DIFF
--- a/lime/src/node.js
+++ b/lime/src/node.js
@@ -995,6 +995,7 @@ lime.Node.prototype.setChildIndex = function(child,index){
 
 /**
  * @inheritDoc
+ * @private
  */
 lime.Node.prototype.listen = function(type, handler,
         opt_capture, opt_handlerScope) {


### PR DESCRIPTION
Node.listen threw an exception if listen was an array (e.g., `something.listen(['touchstart', 'mousedown'], handler)`).
