### PR TITLE
Don't prevent default for all events

### DIFF
--- a/lime/src/events/eventdispatcher.js
+++ b/lime/src/events/eventdispatcher.js
@@ -178,7 +178,17 @@ lime.events.EventDispatcher.prototype.handleEvent = function(e) {
 
     }
 
-    if (didhandle)
-    e.preventDefault();
+    if (didhandle && this.shouldPreventDefault(e.type)) {
+        e.preventDefault();
+    }
+};
 
+/**
+ * If an event of the given type should be allowed to have default behavior.
+ */
+lime.events.EventDispatcher.prototype.shouldPreventDefault = function(type) {
+    if (goog.string.startsWith(type, "key")) {
+        return false;
+    }
+    return true;
 };


### PR DESCRIPTION
Preventing the default for all events really stinks for keyboard events in particular, as ctrl-r, ctrl-~, etc. stop working which makes debugging a lot slower.
