### PR TITLE
Problem with circles rendered in webkit canvas

### DIFF
--- a/lime/src/fill/image.js
+++ b/lime/src/fill/image.js
@@ -240,7 +240,7 @@ lime.fill.Image.prototype.setCanvasStyle = function(context,shape) {
         context.translate(frame.left+offset.x,frame.top+offset.y);
         context.scale(aspx,aspy);
         context.fillStyle = ptrn;
-        if (shape.id === 'circle' || shape.id === 'roundedrect') {
+        if (shape instanceof lime.Circle || shape instanceof lime.RoundedRect) {
             context.fill();
         } else {
             context.fillRect(-offset.x / aspx, -offset.y / aspy, size.width / aspx, size.height / aspy);

--- a/lime/src/shape/circle.js
+++ b/lime/src/shape/circle.js
@@ -65,23 +65,11 @@ lime.Renderer.DOM.CIRCLE.draw = function(el) {
 };
 
 /**
- * @inheritDoc
- * @this {lime.Circle}
+ * Draw the shape path in canvas
+ * @private
  */
-lime.Renderer.CANVAS.CIRCLE.draw = function(context) {
-    var fill = this.getFill(),
-        stroke = this.getStroke(),
-        ap = this.getAnchorPoint(),
-        frame = this.getFrame(),
-        cx = (frame.right - frame.left) * .5,
-        cy = (frame.bottom - frame.top) * .5;
-
-    if (stroke !== null) {
-        cx -= stroke.width_ / 2;
-        cy -= stroke.width_ / 2;
-    }
-
-    context.save();
+lime.Circle.prototype.makeCanvasPath_ = function(context, cx, cy) {
+    var ap = this.getAnchorPoint();
     context.save();
     context.scale(cx, cy);
     context.translate(1 - 2 * ap.x, 1 - 2 * ap.y);
@@ -89,18 +77,31 @@ lime.Renderer.CANVAS.CIRCLE.draw = function(context) {
     context.arc(0, 0, 1, 0, 2 * Math.PI, false);
     context.closePath();
     context.restore();
+};
+
+/**
+ * @inheritDoc
+ * @this {lime.Circle}
+ */
+lime.Renderer.CANVAS.CIRCLE.draw = function(context) {
+    var fill = this.getFill(),
+        stroke = this.getStroke(),
+        frame = this.getFrame(),
+        cx = (frame.right - frame.left) * .5,
+        cy = (frame.bottom - frame.top) * .5;
 
     if (fill !== null) {
+        this.makeCanvasPath_(context, cx, cy);
         fill.setCanvasStyle(context, this);
 
-        if (fill.id !== 'image') {
+        if (!(fill instanceof lime.fill.Image)) {
             context.fill();
         }
     }
 
     if (stroke !== null) {
+        this.makeCanvasPath_(context, cx - stroke.width_ / 2, cy - stroke.width_ / 2);
         stroke.setCanvasStyle(context, this);
         context.stroke();
     }
-    context.restore();
 };

--- a/lime/src/shape/roundedrect.js
+++ b/lime/src/shape/roundedrect.js
@@ -73,6 +73,26 @@ lime.Renderer.DOM.ROUNDEDRECT.draw = function(el) {
 };
 
 /**
+ * Draw the shape path in canvas
+ * @private
+ */
+lime.RoundedRect.prototype.makeCanvasPath_ = function(context, x, y, width, height, radius) {
+    context.save();
+    context.beginPath();
+    context.moveTo(x + radius, y);
+    context.lineTo(x + width - radius, y);
+    context.quadraticCurveTo(x + width, y, x + width, y + radius);
+    context.lineTo(x + width, y + height - radius);
+    context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
+    context.lineTo(x + radius, y + height);
+    context.quadraticCurveTo(x, y + height, x, y + height - radius);
+    context.lineTo(x, y + radius);
+    context.quadraticCurveTo(x, y, x + radius, y);
+    context.closePath();
+    context.restore();
+};
+
+/**
  * @inheritDoc
  * @this {lime.RoundedRect}
  */
@@ -87,31 +107,18 @@ lime.Renderer.CANVAS.ROUNDEDRECT.draw = function(context) {
         width = frame.right - frame.left,
         height = frame.bottom - frame.top;
 
-    context.save();
-    context.beginPath();
-    context.moveTo(x + radius, y);
-    context.lineTo(x + width - radius, y);
-    context.quadraticCurveTo(x + width, y, x + width, y + radius);
-    context.lineTo(x + width, y + height - radius);
-    context.quadraticCurveTo(x + width, y + height, x + width - radius, y + height);
-    context.lineTo(x + radius, y + height);
-    context.quadraticCurveTo(x, y + height, x, y + height - radius);
-    context.lineTo(x, y + radius);
-    context.quadraticCurveTo(x, y, x + radius, y);
-    context.closePath();
-
     if (fill !== null) {
+        this.makeCanvasPath_(context, x, y, width, height, radius);
         fill.setCanvasStyle(context, this);
 
-        if (fill.id !== 'image') {
+        if (!(fill instanceof lime.fill.Image)) {
             context.fill();
         }
     }
 
     if (stroke !== null) {
+        this.makeCanvasPath_(context, x + stroke.width_ / 2, y + stroke.width_ / 2, width - stroke.width_, height - stroke.width_, radius - stroke.width_ / 2);
         stroke.setCanvasStyle(context, this);
         context.stroke();
     }
-
-    context.restore();
 };


### PR DESCRIPTION
For quite a while I have been noticing that the borders of circles are rendered with a lot of imperfections when the canvas renderer is used in webkit based browsers:
![1](https://f.cloud.github.com/assets/1474080/2162915/40aa0702-94d8-11e3-95ae-f636387f7dfa.png)
Our games have a lot of circular elements, and the quality of them is quite noticeably degraded when rendered with canvas. And it is because of this that we have been avoiding using it.

But I have now decided to investigate why this is happening and found that it is the clip method of the webkit implementation of canvas that is causing this. So I have made a small change to draw circles using the fill method and it corrected it for most fill types except images.
![2](https://f.cloud.github.com/assets/1474080/2162940/7d4350d8-94d8-11e3-8664-6c172e9961b0.png)
Those changes are available here: https://github.com/aurhe/limejs/commit/3cd8ccb5e54422667643a2dc0b3befe1f44ae13e but still lack proper testing, and I still have not found a way for drawing rounded images in canvas without using the clip method.

So my question is: Should the drawing method be changed to this only for circles and roundrects? Or will we continue waiting for this to be corrected in webkit?

I have been seeing this problem in webkit based browsers for a while and I personally wouldn't count that it will be fixed anytime soon.
