### PR TITLE
Add lime.Layer as a requirement for lime.ui.Scroller

### DIFF
--- a/lime/src/ui/scroller.js
+++ b/lime/src/ui/scroller.js
@@ -1,5 +1,6 @@
 goog.provide('lime.ui.Scroller');
 
+goog.require('lime.Layer');
 goog.require('lime.Sprite');
 goog.require('lime.animation.MoveTo');
 


### PR DESCRIPTION
lime.ui.Scroller was using lime.Layer without requiring it.
