### PR TITLE
Fix for IE9 and IE10 with running out of storage.

### DIFF
--- a/lime/src/fill/frame.js
+++ b/lime/src/fill/frame.js
@@ -137,9 +137,7 @@ lime.fill.Frame.prototype.makeFrameData_ = function(){
             styleSheet = document.styleSheets[document.styleSheets.length-1];
         }
         else {
-            // why doesn't addCssRule work in IE9???
-           if (goog.userAgent.IE) styleSheet.cssText += rule;
-           else goog.cssom.addCssRule(styleSheet,rule);
+            goog.cssom.addCssRule(styleSheet,rule);
         }
 
         // loading into image to avoid flickery onf firefox first load


### PR DESCRIPTION
Was running into
SCRIPT14: Not enough storage is available to complete this operation.

frame.js, line 141 character 30

on IE9 and IE10

Reverted to just using addCssRule and it has been working just fine. Maybe this was an issue with a previous version of google closure?
