### PR TITLE
Add missing ';'

### DIFF
--- a/lime/src/scene.js
+++ b/lime/src/scene.js
@@ -28,4 +28,4 @@ lime.Scene.prototype.getScene = function() {
 /** @inheritDoc */
 lime.Scene.prototype.measureContents = function() {
     return this.getFrame();
-}
+};


### PR DESCRIPTION
Prevents the following error:

```
Running "closureCompiler:all" (closureCompiler) task
Executing: java  -jar "limejs/bin/external/compiler-20130411.jar"  --js dist/js/foo.js --
js_output_file=dist/js/foo.min.js
>> Error: Command failed: dist\js\foo.js:29509: ERROR - Parse error. missing ; before statement
>> }goog.provide('lime.Button');
>>  ^
>>
>> 1 error(s), 0 warning(s)
>> FAILED to run command for target: all
```
