### PR TITLE
Change ViewportSizeMonitor using singleton

### DIFF
--- a/lime/src/director.js
+++ b/lime/src/director.js
@@ -113,7 +113,7 @@ lime.Director = function(parentElement, opt_width, opt_height) {
     this.setPaused(false);
 
 
-    var vsm = new goog.dom.ViewportSizeMonitor();
+    var vsm = goog.dom.ViewportSizeMonitor.getInstanceForWindow();
     goog.events.listen(vsm, goog.events.EventType.RESIZE,
         this.invalidateSize_, false, this);
     goog.events.listen(goog.global, 'orientationchange',


### PR DESCRIPTION
For managing instance of ViewportSizeMonitor, I changed usage of using ViewportSizeMonitor.

Document : http://docs.closure-library.googlecode.com/git/class_goog_dom_ViewportSizeMonitor.html
