### PR TITLE
Advanced optimizations with additional option for longer names renaming

### DIFF
--- a/bin/lime.py
+++ b/bin/lime.py
@@ -288,6 +288,9 @@ def build(name,options):
     if options.advanced:
         call+=" -f --compilation_level=ADVANCED_OPTIMIZATIONS"
         
+    if options.debug:
+        call+=" -f --debug -f --formatting=PRETTY_PRINT"
+        
     if options.externs_file:
         for i, opt in enumerate(options.externs_file):
             call+=" -f --externs="+opt
@@ -385,6 +388,9 @@ Commands:
     
     parser.add_option("-a", "--advanced", dest="advanced", action="store_true",
                       help="Build uses ADVANCED_OPTIMIZATIONS mode (encouraged)")
+                      
+    parser.add_option("-g", "--debug", dest="debug", action="store_true",
+                      help="Closure Compiler: longer names for symbols for debugging of the advanced optimizations.")
 
     parser.add_option('-e', '--externs', dest="externs_file", action='append',
                       help="File with externs declarations.")


### PR DESCRIPTION
Add an ability to debug after the Google Closure Compiler with advanced optimizations. Closure Compiler will rename all your symbols, but it will give them longer names so that you can figure out what the original name was.

Example of renaming:  **className.subClass.Method** will be renamed to **$className$subClass$Method$$**

Maybe it will help to define a problem with the new version of Google Closure Compiler after  advanced compilation of LimeJS core.


THIS INFO FROM 
 https://github.com/google/closure-compiler/wiki/FAQ#my-code-broke-when-using-advanced-optimizations-how-do-i-figure-out-whats-wrong
My code broke when using advanced optimizations! How do I figure out what's wrong?

Use the --debug flag combined with the --formatting=PRETTY_PRINT flag.

When you're using the --debug flag, Closure Compiler will rename all your symbols, but it will give them longer names so that you can figure out what the original name was.

If you are using ADVANCED optimizations, you may also want to disable the type-based optimizations with --use_types_for_optimization false. Incorrect type optimizations can cause the compiler to make invalid assumptions.